### PR TITLE
fixed duplicate function

### DIFF
--- a/src/ansys/aedt/core/modeler/modeler_pcb.py
+++ b/src/ansys/aedt/core/modeler/modeler_pcb.py
@@ -758,7 +758,7 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         self.cleanup_objects()
         if isinstance(assignment, str):
             assignment = [assignment]
-        self.oeditor.Duplicate(["NAME:options", "count:=", count], ["NAME:elements", ",".join(assignment)], vector)
+        self.oeditor.Duplicate(["NAME:options", "count:=", count], ["NAME:elements"] + assignment, vector)
         return self.cleanup_objects()
 
     @pyaedt_function_handler(objects="assignment")


### PR DESCRIPTION
Updated the duplicate function in modeler_pcb.py file line 761 to allow function to handle a list of items passed to be duplicated.